### PR TITLE
image clickthrough link fix for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Preview | Description
 ------------ | -------------
 [<img src="http://i.imgur.com/TvYhCHn.jpg" width="150" />](http://i.imgur.com/AfFMkHe.jpg) | A visual guide to Becoming a Data Scientist in 8 Steps by [DataCamp](https://www.datacamp.com) [(img)](http://i.imgur.com/AfFMkHe.jpg)
 [<img src="http://i.imgur.com/W2t2Roz.png" width="150" />](http://i.imgur.com/FxsL3b8.png) | Mindmap on required skills ([img](http://i.imgur.com/FxsL3b8.png))
-[<img src="http://i.imgur.com/rb9ruaa.png" width="150" />](http://i.imgur.com/FxsL3b8.png) | Swami Chandrasekaran made a [Curriculum via Metro map](http://nirvacana.com/thoughts/becoming-a-data-scientist/).
+[<img src="http://i.imgur.com/rb9ruaa.png" width="150" />](http://nirvacana.com/thoughts/wp-content/uploads/2013/07/RoadToDataScientist1.png) | Swami Chandrasekaran made a [Curriculum via Metro map](http://nirvacana.com/thoughts/becoming-a-data-scientist/).
 [<img src="http://i.imgur.com/XBgKF2l.png" width="150" />](http://i.imgur.com/4ZBBvb0.png) | by [@kzawadz](https://twitter.com/kzawadz) via [twitter](https://twitter.com/MktngDistillery/status/538671811991715840), [MarketingDistillery.com](http://www.marketingdistillery.com/2014/11/29/is-data-science-a-buzzword-modern-data-scientist-defined/)
 
 


### PR DESCRIPTION
Fixed 3rd infographic preview when you click on the image.

Action: Click on **3rd** infographic preview
Before: Displays **2nd** infographic preview
Now: Goes to http://nirvacana.com/thoughts/wp-content/uploads/2013/07/RoadToDataScientist1.png displaying the proper image.