### PR TITLE
Add new Data sets: New Zealand Institute of Economic Research Data1850

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Preview | Description
 * [MapLight](http://maplight.org/data) - provides a variety of data free of charge for uses that are freely available to the general public. Click on a data set below to learn more
 * [GHDx](http://ghdx.healthdata.org/catalog) - Institute for Health Metrics and Evaluation - a catalog of health and demographic datasets from around the world and including IHME results
 * [St. Louis Federal Reserve Economic Data - FRED](http://research.stlouisfed.org/fred2/)
+* [New Zealand Institute of Economic Research – Data1850](https://data1850.nz/)
 * [Dept. of Politics @ New York University](http://www.nyu.edu/projects/politicsdatalab/data_classic_sources.html)
 * [Open Data Sources](https://github.com/datasciencemasters/data)
 * [UNICEF Statistics and Monitoring](http://www.unicef.org/statistics/)


### PR DESCRIPTION
Multiple datasets related to the New Zealand economy. All time series, some of them quite long (pre 1900).