### PR TITLE
Remove https://www.datasciencegame.com from Competitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,6 @@ Some data mining competition platforms
 - [Kaggle](https://www.kaggle.com/)
 - [DrivenData](https://www.drivendata.org/)
 - [Analytics Vidhya](http://datahack.analyticsvidhya.com/)
-- [The Data Science Game](http://www.datasciencegame.com/)
 - [InnoCentive](https://www.innocentive.com/)
 - [TuneedIT](http://tunedit.org/challenges)
 - [Microprediction](https://www.microprediction.com/python-1)


### PR DESCRIPTION
Remove www.datasciencegame.com from **Competitions** sections. The website is hacked long time ago.