### PR TITLE
Add data science skill tree to MOOCs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ How do you learn data science? By doing data science, of course! Okay, okay - th
 - [Data Scientist with Python](https://app.datacamp.com/learn/career-tracks/data-scientist-with-python)
 - [Programming with Julia](https://www.udemy.com/course/programming-with-julia/)
 - [Scaler Data Science & Machine Learning Program](https://www.scaler.com/data-science-course/)
-
+- [Data Science Skill Tree](https://labex.io/skilltrees/data-science)
 
 
 ### Intensive Programs


### PR DESCRIPTION
Add LabEx Data Science skill tree to MOOCs section

I work at LabEx, a unique learning platform that has delivered thousands of free and paid hands-on labs over the past 7 years. Our data science skill tree currently offers 212 skills and 91 hands-on peojects, making it perfect for beginners to learn step by step.

This repo is a great resource. Please let me know if any changes are needed.