### PR TITLE
Add DuckDB and Metabase to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ These are some Machine Learning and Data Mining algorithms and models help you t
 - [r2d3](http://www.r2d3.us/visual-intro-to-machine-learning-part-1/)
 - [NetworkX](https://networkx.org/)
 - [Redash](https://redash.io/)
+- [Metabase](https://www.metabase.com/)
 - [C3](https://c3js.org/)
 - [TensorWatch](https://github.com/microsoft/tensorwatch)
 - [geomap](https://pypi.org/project/geomap/)
@@ -582,6 +583,7 @@ These are some Machine Learning and Data Mining algorithms and models help you t
 | [Amazon CodeGuru](https://aws.amazon.com/codeguru/) | Automate code reviews and optimize application performance with ML-powered recommendations.|
 | [CML](https://github.com/iterative/cml) | An open source toolkit for using continuous integration in data science projects. Automatically train and test models in production-like environments with GitHub Actions & GitLab CI, and autogenerate visual reports on pull/merge requests. |
 | [Dask](https://dask.org/) | An open source Python library to painlessly transition your analytics code to distributed computing systems (Big Data) |
+| [DuckDB](https://github.com/duckdb/duckdb) | An in-process SQL OLAP database management system |
 | [Statsmodels](https://www.statsmodels.org/stable/index.html) | A Python-based inferential statistics, hypothesis testing and regression framework |
 | [Gensim](https://radimrehurek.com/gensim/) | An open-source library for topic modeling of natural language text |
 | [spaCy](https://spacy.io/) | A performant natural language processing toolkit |


### PR DESCRIPTION
Added two widely-used tools that were missing from the list:

- **DuckDB** in the Miscellaneous Tools section — an in-process SQL OLAP database that's become very popular for data science workflows
- **Metabase** in the Visualization Tools section — an open source BI tool for data exploration and dashboards, similar to Redash which is already listed
