### PR TITLE
Add GBIF and FAOSTAT open datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,8 @@ Some data mining competition platforms
 - [Google Dataset Search](https://datasetsearch.research.google.com/) – Find datasets across the web.
 - [notesjor corpus-collection](https://notes.jan-oliver-ruediger.de/korpora/) - Free corpora (over 6 billion tokens) mostly German (both historically and in contemporary German).
 - [CLARIN-Repository](https://lindat.mff.cuni.cz/repository/home) - CLARIN is a European repository for scientific datasets.
+- [GBIF](https://www.gbif.org/) - Global Biodiversity Information Facility: 2.4B+ species occurrence records. Free, open API for ecological modeling and ML research.
+- [FAOSTAT](https://www.fao.org/faostat/en/) - UN FAO statistics on food production, trade, land use, and emissions for 245+ countries. Free API and bulk download.
 
 
 ### Comics


### PR DESCRIPTION
Adds two widely-used open datasets that were missing from the list:

- **GBIF** (Global Biodiversity Information Facility) — 2.4B+ species occurrence records with a free open API, widely used in ecological modeling and ML research.
- **FAOSTAT** — UN FAO statistics on food production, trade, land use, and emissions for 245+ countries, with a free API and bulk download.