### PR TITLE
Add Deploybase

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ These are some Machine Learning and Data Mining algorithms and models help you t
 | [RunMat](https://github.com/runmat-org/runmat) | Fast MATLAB-syntax runtime with automatic CPU/GPU execution and fused array kernels. |
 | [Turbostream](https://github.com/turboline-ai/turbostream) | A terminal UI for experimenting with custom rule engines and selective LLM analysis on real-time data streams, without worrying about streaming infra or backpressure. |
 | [WFGY ProblemMap](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) | Open source “failure atlas” of 16 recurring issues in LLM and RAG pipelines, with observable symptoms and suggested fixes for data science teams. |
+| [Deploybase](https://deploybase.ai/) | Track real-time GPU and LLM pricing across all cloud and inference providers. |
 
 
 


### PR DESCRIPTION
Adding Deploybase, a real-time GPU and LLM pricing aggregator dashboard that tracks pricing across all major cloud and inference providers. Useful for data scientists comparing compute costs.