### PR TITLE
Add Frostbyte MCP to Agents > Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Please, contribute about "agents"
 ### Frameworks
 - [ADK-Rust](https://github.com/zavora-ai/adk-rust) - Production-ready AI agent development kit for Rust with model-agnostic design (Gemini, OpenAI, Anthropic), multiple agent types (LLM, Graph, Workflow), MCP support, and built-in telemetry.
 
+### Tools
+- [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) - MCP server providing 13 data tools for AI agents: real-time crypto prices, IP geolocation, DNS lookups, web scraping to markdown, code execution, and screenshots. One API key for 40+ services.
+
 ### Workflow  
 **[`^        back to top        ^`](#awesome-data-science)**
 - [sim](https://sim.ai) Sim Studio's interface is a lightweight, intuitive way to quickly build and deploy LLMs that connect with your favorite tools.


### PR DESCRIPTION
Adds [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) to the **Agents > Tools** subsection.

Frostbyte MCP is an MCP server that gives AI agents access to 13 data tools:
- Real-time cryptocurrency prices (BTC, ETH, SOL, 100+ tokens)
- IP geolocation (country, city, ISP, timezone)
- DNS lookups (A, MX, NS, TXT records)
- Web scraping to clean markdown
- Live code execution (Python, JavaScript, TypeScript, Bash)
- Website screenshots
- And more

One API key connects to 40+ services. Free tier with 200 credits, no credit card required.

The Agents section currently has very few entries and explicitly invites contributions — this adds a practical data tool that agents can use for research and analysis workflows.