### PR TITLE
fix: update GitHub Actions and fix deprecated CDN links

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -9,10 +9,10 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: gaurav-nelson/github-action-markdown-link-check@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 # AWESOME DATA SCIENCE
 
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) 
+[![Awesome](https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) 
 
 **An open-source Data Science repository to learn and apply concepts toward solving real- world problems.**
 


### PR DESCRIPTION
This PR fixes a couple of reliability issues with automated workflows and badges:

- **GitHub Actions updates**: Replaced deprecated `@master` references with proper version tags (`@v4` for checkout, `@v1` for markdown-link-check) to prevent workflow failures
- **CDN fix**: Updated the Awesome badge from the shutdown `cdn.rawgit.com` to `cdn.jsdelivr.net` so the badge displays correctly again

These changes ensure the link checking workflow runs reliably and the repository badge displays properly on GitHub.