### PR TITLE
Add Techpresso newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ This section includes some additional reading material, channels to watch, and t
 
 - [DataTalks.Club](https://datatalks.club). A weekly newsletter about data-related things. [Archive](https://us19.campaign-archive.com/home/?u=0d7822ab98152f5afc118c176&id=97178021aa).
 - [The Analytics Engineering Roundup](https://roundup.getdbt.com/about). A newsletter about data science. [Archive](https://roundup.getdbt.com/archive).
+- [Techpresso](https://dupple.com/techpresso). A free daily newsletter covering the most impactful developments in AI, ML, and tech. [Archive](https://dupple.com/techpresso).
 
 ### Mailing lists
 **[`^        back to top        ^`](#awesome-data-science)**


### PR DESCRIPTION
Adds [Techpresso](https://dupple.com/techpresso) to the Newsletters section.

Techpresso is a free daily AI & tech newsletter covering the most impactful developments in AI, ML, and tech.