### PR TITLE
Add latamdata-py – Python package for Latin American research datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,6 +1172,7 @@ Some data mining competition platforms
 - [GBIF](https://www.gbif.org/) - Global Biodiversity Information Facility: 2.4B+ species occurrence records. Free, open API for ecological modeling and ML research.
 - [FAOSTAT](https://www.fao.org/faostat/en/) - UN FAO statistics on food production, trade, land use, and emissions for 245+ countries. Free API and bulk download.
 - [FirstData](https://github.com/MLT-OSS/FirstData) - The world's most comprehensive authoritative data source knowledge base. 210+ curated sources from governments, international organizations, and research institutions. MCP integration for AI agents. MIT licensed.
+- [latamdata-py](https://github.com/juanmoisesd/latamdata-py) - Python package for one-line access to 38 open research datasets from Latin America (health, neuroscience, mental health, economics). pip install latamdata-py.
 
 
 ### Comics


### PR DESCRIPTION
## Description

Adding [latamdata-py](https://github.com/juanmoisesd/latamdata-py), a Python package that provides one-line access to 38 open research datasets from Latin America.

```python
pip install latamdata-py
```

**Datasets cover:** health, neuroscience, mental health, economics, and more — all open science, CC-BY-4.0 licensed.

## Checklist
- [x] The entry follows the existing format
- [x] The link is valid and the repository is public
- [x] Added in the Datasets section