### PR TITLE
Add Congressional Stock Brain to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,7 @@ Some data mining competition platforms
 - [datacite.org](https://datacite.org/)
 - [The official portal for European data](https://data.europa.eu/en)
 - [NASDAQ:DATA](https://data.nasdaq.com/) - Nasdaq Data Link A premier source for financial, economic and alternative datasets.
+- [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI-powered tool that scores U.S. congressional STOCK Act trade disclosures by significance. Machine-scored signals from 537 lawmakers's public trade filings.
 - [figshare.com](https://figshare.com/)
 - [GeoLite Legacy Downloadable Databases](https://dev.maxmind.com/geoip)
 - [Hugging Face Datasets](https://huggingface.co/datasets)


### PR DESCRIPTION
Adds Congressional Stock Brain (congressionalstockbrain.com) to the Datasets section, alongside NASDAQ:DATA and other financial data sources.

Congressional Stock Brain is a free AI-powered tool that ingests U.S. STOCK Act disclosures (publicly filed congressional trade filings) and converts them into machine-scored signals for data scientists and retail investors. It applies AI scoring based on committee assignment relevance, timing vs. legislative activity, and trade significance.

This is a unique alternative dataset — political/legislative trading data — that is not well-represented in data science resource lists. Free to use, no login required, 537 lawmakers tracked.