### PR TITLE
Add Japan Neighborhoods to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ Some data mining competition platforms
 - [figshare.com](https://figshare.com/)
 - [GeoLite Legacy Downloadable Databases](https://dev.maxmind.com/geoip)
 - [Hugging Face Datasets](https://huggingface.co/datasets)
+- [Japan Neighborhoods](https://japanneighborhoods.com) - English dataset of Tokyo crime statistics across 5,078 neighborhoods × 7 years (36,222 records, 2018-2024), sourced from Tokyo Metropolitan Police open data. Includes interactive crime map, safety grading, and cost-of-living index. CC BY licensed.
 - [Quora's Big Datasets Answer](https://www.quora.com/Where-can-I-find-large-datasets-open-to-the-public)
 - [Public Big Data Sets](https://hadoopilluminated.com/hadoop_illuminated/Public_Bigdata_Sets.html)
 - [Kaggle Datasets](https://www.kaggle.com/datasets)


### PR DESCRIPTION
Adds **Japan Neighborhoods** to the Datasets section.

English dataset of Tokyo crime statistics:
- 5,078 neighborhoods × 7 years (36,222 records, 2018-2024)
- Sourced from Tokyo Metropolitan Police open data
- Interactive crime map, safety grading (A+ to F), cost-of-living index
- CC BY licensed
- Also available on Kaggle, data.world, and figshare