### PR TITLE
Add Not Human Search to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This section contains agent frameworks and tools that are useful for data scienc
 ### Tools
 - [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) - MCP server providing 13 data tools for AI agents: real-time crypto prices, IP geolocation, DNS lookups, web scraping to markdown, code execution, and screenshots. One API key for 40+ services.
 - [Arch Tools](https://archtools.dev) - 61 production-ready AI API tools for data science workflows: code analysis, web scraping, NLP, image generation, crypto data, and search. REST API and MCP protocol support. [GitHub](https://github.com/Deesmo/Arch-AI-Tools)
+- [Not Human Search](https://nothumansearch.ai) - Search engine for AI agents that indexes 9,000+ AI tools and APIs, scoring each on agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json). REST API and MCP server for programmatic tool discovery. [GitHub](https://github.com/unitedideas/nothumansearch)
 
 ### Research & Knowledge Retrieval
 - [BGPT MCP](https://bgpt.pro/mcp) - MCP server that gives AI agents access to a database of scientific papers built from raw experimental data extracted from full-text studies. Returns 25+ structured fields per paper including methods, results, sample sizes, and quality scores. [GitHub](https://github.com/connerlambden/bgpt-mcp)


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) to the Tools section.

Not Human Search is a search engine for AI agents that indexes 9,000+ AI tools and APIs, scoring each on agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json). It's available as both a REST API and MCP server for programmatic tool discovery.

- **Website:** https://nothumansearch.ai
- **GitHub:** https://github.com/unitedideas/nothumansearch
- **OpenAPI spec:** https://nothumansearch.ai/openapi.yaml
- **MCP server:** https://nothumansearch.ai/mcp