### PR TITLE
Add Crime Brasil to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,7 @@ Some data mining competition platforms
 - [GeoLite Legacy Downloadable Databases](https://dev.maxmind.com/geoip)
 - [Hugging Face Datasets](https://huggingface.co/datasets)
 - [Japan Neighborhoods](https://japanneighborhoods.com) - English dataset of Tokyo crime statistics across 5,078 neighborhoods × 7 years (36,222 records, 2018-2024), sourced from Tokyo Metropolitan Police open data. Includes interactive crime map, safety grading, and cost-of-living index. CC BY licensed.
+- [Crime Brasil](https://crimebrasil.com.br) - Open-data platform for Brazilian crime statistics. Neighborhood-level in Rio Grande do Sul (2.99M incidents across 79,024 neighborhoods, 2022–2025), municipality-level for MG and RJ, plus national PRF highway and DATASUS interpersonal-violence data. Free REST API, CSV/Parquet, daily updates, CC BY 4.0.
 - [Quora's Big Datasets Answer](https://www.quora.com/Where-can-I-find-large-datasets-open-to-the-public)
 - [Public Big Data Sets](https://hadoopilluminated.com/hadoop_illuminated/Public_Bigdata_Sets.html)
 - [Kaggle Datasets](https://www.kaggle.com/datasets)


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) to the Datasets section, placed next to Japan Neighborhoods for thematic clustering (both are neighborhood-level crime-data platforms at country scale).

**Dataset scope:**
- Rio Grande do Sul: 2.99M incidents 2022–2025, 497 municipalities, 79,024 neighborhoods, 99.99% geocoded
- Minas Gerais: ~965K violent crimes (municipality-level)
- Rio de Janeiro: ~37K ISP/CISP records (municipality-level)
- National: PRF DATATRAN (federal highway accidents, 2020–2026) + DATASUS SINAN (interpersonal violence, 2009–2024)

**Access:** Free REST API, CSV/Parquet exports, daily updates, CC BY 4.0 license.

Disclosure: I'm the maintainer of Crime Brasil.