### PR TITLE
Add chunktuner to Agents (research & knowledge retrieval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ This section contains agent frameworks and tools that are useful for data scienc
 
 ### Research & Knowledge Retrieval
 - [BGPT MCP](https://bgpt.pro/mcp) - MCP server that gives AI agents access to a database of scientific papers built from raw experimental data extracted from full-text studies. Returns 25+ structured fields per paper including methods, results, sample sizes, and quality scores. [GitHub](https://github.com/connerlambden/bgpt-mcp)
+- [Chunk Tuner](https://github.com/shantanu-deshmukh/chunktuner) - Open-source Python library and MCP server to benchmark document chunking strategies for RAG, score retrieval quality, and recommend configurations for a corpus.
 
 ### Workflow
 **[`^        back to top        ^`](#awesome-data-science)**


### PR DESCRIPTION
Adds [chunktuner](https://github.com/shantanu-deshmukh/chunktuner) to the **Agents** area of Awesome Data Science, under knowledge/RAG-adjacent tooling.

### Why it belongs

- **Data science practitioners increasingly ship RAG:** tuning chunk boundaries and comparing strategies is usually done ad hoc; chunktuner brings **experimentation and metrics** (retrieval scores, optional RAGAS) to that step.
- **Fits DS workflows:** Python-first, CLI for reproducible studies, MCP for exploratory work with coding assistants—aligned with how teams prototype retrieval systems.