### PR TITLE
Add Packrift packaging optimization benchmark corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ Some data mining competition platforms
 - [Academic Torrents](https://academictorrents.com/)
 - [ADS-B Exchange](https://www.adsbexchange.com/data-samples/) - Specific datasets for aircraft and Automatic Dependent Surveillance-Broadcast (ADS-B) sources.
 - [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured dataset tracking 92 AI-attributed workforce reduction events affecting 453,748 workers across 12 countries and 11 sectors. JSON and CSV formats. CC-BY-4.0 licensed.
+- [Packrift Packaging Optimization Benchmark Corpus](https://packrift.github.io/packaging-optimization-benchmark-corpus/) - Public packaging product dataset generated from 1,000 exact-spec SKU records, with downloadable CSV and JSON files for ecommerce fulfillment and warehouse analysis.
 - [hadoopilluminated.com](https://hadoopilluminated.com/hadoop_illuminated/Public_Bigdata_Sets.html)
 - [data.gov](https://catalog.data.gov/dataset) - The home of the U.S. Government's open data
 - [United States Census Bureau](https://www.census.gov/)


### PR DESCRIPTION
Adds a neutral public-dataset entry for the Packrift Packaging Optimization Benchmark Corpus under the Datasets section.

The linked dataset page is public and exposes downloadable data files:

- Quality ledger CSV: https://packrift.github.io/packaging-optimization-benchmark-corpus/data/quality-ledger.csv
- Manifest JSON: https://packrift.github.io/packaging-optimization-benchmark-corpus/data/manifest.json

Validation performed:

- Confirmed the dataset homepage returns HTTP 200.
- Kept the change to a single README bullet in the existing Datasets section style.