### PR TITLE
Add The Quiet-Broke Index to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,7 @@ Some data mining competition platforms
 - [GeoLite Legacy Downloadable Databases](https://dev.maxmind.com/geoip)
 - [Hugging Face Datasets](https://huggingface.co/datasets)
 - [Japan Neighborhoods](https://japanneighborhoods.com) - English dataset of Tokyo crime statistics across 5,078 neighborhoods × 7 years (36,222 records, 2018-2024), sourced from Tokyo Metropolitan Police open data. Includes interactive crime map, safety grading, and cost-of-living index. CC BY licensed.
+- [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite ranking of how much of a $400K household income gets consumed by housing, taxes, childcare, healthcare, and transport. Open methodology, free, no email gate.
 - [Crime Brasil](https://crimebrasil.com.br) - Open-data platform for Brazilian crime statistics. Neighborhood-level in Rio Grande do Sul (2.99M incidents across 79,024 neighborhoods, 2022–2025), municipality-level for MG and RJ, plus national PRF highway and DATASUS interpersonal-violence data. Free REST API, CSV/Parquet, daily updates, CC BY 4.0.
 - [Quora's Big Datasets Answer](https://www.quora.com/Where-can-I-find-large-datasets-open-to-the-public)
 - [Public Big Data Sets](https://hadoopilluminated.com/hadoop_illuminated/Public_Bigdata_Sets.html)


### PR DESCRIPTION
## What is this?

**[The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/)** is a free, no-login composite ranking of 30 US metros showing what percentage of a $400K household income gets consumed by five unavoidable cost categories: housing, federal/state/local taxes, childcare, healthcare, and transportation.

## Why it fits the Datasets section

- Open methodology (all cost model weights and data sources documented at the [methodology page](https://jeevesagency.github.io/quiet-broke-index/methodology.html))
- Free and ungated — no email required, no paywall
- Sourced from publicly available government and survey data (Census ACS, BLS Consumer Expenditure Survey, HUD Fair Market Rents, Tax Foundation, etc.)
- Interactive explorer with per-metro breakdowns, useful as a reference dataset for cost-of-living research

## Entry added

Under `### Datasets`:

```
- [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite ranking of how much of a $400K household income gets consumed by housing, taxes, childcare, healthcare, and transport. Open methodology, free, no email gate.
```

Placed near other cost-of-living and neighborhood-level data entries (Japan Neighborhoods, Open Data Philly) for thematic proximity.